### PR TITLE
 Remove redundant build flags

### DIFF
--- a/org.gnome.SwellFoop.json
+++ b/org.gnome.SwellFoop.json
@@ -17,10 +17,6 @@
         "--talk-name=ca.desrt.dconf",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
-    "build-options" : {
-        "cflags" : "-O2 -g",
-        "cxxflags": "-O2 -g"
-    },
     "cleanup": [
     ],
     "modules" : [


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.